### PR TITLE
fix: removed required as

### DIFF
--- a/functions/update/1.0/function.json
+++ b/functions/update/1.0/function.json
@@ -43,9 +43,6 @@
         "output": {
           "type": "Record",
           "model": "selectedRecord"
-        },
-        "validations": {
-          "required": true
         }
       },
       "name": "as",


### PR DESCRIPTION
Removed the required validation from the 'as' input field within the update step